### PR TITLE
Fix for windows 11 24H2 UAC failing for files on a ImDisk Volume

### DIFF
--- a/inc/imdisk.h
+++ b/inc/imdisk.h
@@ -51,6 +51,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 ///
 /// Base names for device objects created in \Device
 ///
+#define IMDISK_UNIQUE_ID_PREFIX         "ImDisk"
 #define IMDISK_DEVICE_DIR_NAME         _T("\\Device")
 #define IMDISK_DEVICE_BASE_NAME        IMDISK_DEVICE_DIR_NAME  _T("\\ImDisk")
 #define IMDISK_CTL_DEVICE_NAME         IMDISK_DEVICE_BASE_NAME _T("Ctl")

--- a/sys/devthrd.cpp
+++ b/sys/devthrd.cpp
@@ -1021,6 +1021,8 @@ ImDiskDeviceThread(IN PVOID Context)
         KeSetEvent(&device_thread_data->created_event, (KPRIORITY)0, FALSE);
     else
     {
+        ImDiskMountManagerMount(device_thread_data->create_data->DriveLetter,
+            device_thread_data->create_data->DeviceNumber);
         ImDiskCreateDriveLetter(device_thread_data->create_data->DriveLetter,
             device_thread_data->create_data->DeviceNumber);
 
@@ -1130,7 +1132,10 @@ ImDiskDeviceThread(IN PVOID Context)
 
             if (device_extension->drive_letter != 0)
                 if (system_drive_letter)
+                {
+                    ImDiskMountManagerUnmount(device_extension->drive_letter);
                     ImDiskRemoveDriveLetter(device_extension->drive_letter);
+                }
 
             ImDiskCloseProxy(&device_extension->proxy);
 

--- a/sys/imdsksys.h
+++ b/sys/imdsksys.h
@@ -50,6 +50,8 @@ Copyright (C) The Regents of the University of California.
 #include <ntddcdrm.h>
 #include <ntverp.h>
 #include <mountmgr.h>
+#include <mountdev.h>
+#include <ntddvol.h>
 #include <stdio.h>
 
 ///
@@ -241,6 +243,13 @@ ImDiskCreateDriveLetter(IN WCHAR DriveLetter,
 NTSTATUS
 ImDiskRemoveDriveLetter(IN WCHAR DriveLetter);
 
+NTSTATUS
+ImDiskMountManagerMount(IN WCHAR DriveLetter,
+    IN ULONG DeviceNumber);
+
+NTSTATUS
+ImDiskMountManagerUnmount(IN WCHAR DriveLetter);
+
 VOID
 ImDiskRemoveVirtualDisk(IN PDEVICE_OBJECT DeviceObject);
 
@@ -354,6 +363,21 @@ ImDiskFloppyFormat(IN PDEVICE_EXTENSION Extension,
     IN PIRP Irp);
 
 #endif // INCLUDE_GPL_ORIGIN
+
+
+typedef enum
+{
+    DeviceNamespaceDefault,
+    DeviceNamespaceGlobal,
+} DeviceNamespaceType;
+
+#define DOS_MOUNT_PREFIX_DEFAULT L"\\DosDevices\\"
+#define DOS_MOUNT_PREFIX_GLOBAL L"\\GLOBAL??\\"
+
+VOID 
+ImDiskGetDosNameFromNumber (LPWSTR dosname, int cbDosName, WCHAR DriveLetter, DeviceNamespaceType namespaceType);
+
+
 
 #ifdef _AMD64_
 


### PR DESCRIPTION
This fix resolves the issues reported at: https://sourceforge.net/p/imdisk-toolkit/discussion/general/thread/041e10fe01/

This change adds mount manager integration to the ImDisk driver and support for a few needed IOCTLs
